### PR TITLE
add GET /api/articles to return all articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -80,3 +80,29 @@ describe("/api/articles/:article_id", () => {
       .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
   });
 });
+
+describe("/api/articles", () => {
+  test("GET: 200 - respond with an array of all article objects sorted by date in descending order", () => {
+    return request(app)
+      .get("/api/articles")
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toHaveLength(13);
+
+        articles.forEach((article) => {
+          expect(article).toMatchObject({
+            author: expect.any(String),
+            title: expect.any(String),
+            article_id: expect.any(Number),
+            topic: expect.any(String),
+            created_at: expect.any(String),
+            votes: expect.any(Number),
+            article_img_url: expect.any(String),
+            comment_count: expect.any(Number),
+          });
+        });
+
+        expect(articles).toBeSortedBy("created_at", { descending: true });
+      });
+  });
+});

--- a/app.js
+++ b/app.js
@@ -1,6 +1,9 @@
 const express = require("express");
 
-const { getArticleById } = require("./controllers/articles.controller");
+const {
+  getArticleById,
+  getAllArticles,
+} = require("./controllers/articles.controller");
 const { getEndpoints } = require("./controllers/endpoints.controller");
 const { getTopics } = require("./controllers/topics.controller");
 
@@ -21,6 +24,8 @@ app.get("/api", getEndpoints);
 app.get("/api/topics", getTopics);
 
 app.get("/api/articles/:article_id", getArticleById);
+
+app.get("/api/articles", getAllArticles);
 
 /**********************************************
  * Error handlers

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,4 +1,7 @@
-const { selectArticleById } = require("../models/articles.model");
+const {
+  selectArticleById,
+  selectAllArticles,
+} = require("../models/articles.model");
 
 function getArticleById(request, response, next) {
   const { article_id } = request.params;
@@ -8,4 +11,9 @@ function getArticleById(request, response, next) {
     .catch(next);
 }
 
-module.exports = { getArticleById };
+function getAllArticles(request, response, next) {
+  return selectAllArticles()
+    .then((rows) => response.status(200).send({ articles: rows }))
+    .catch(next);
+}
+module.exports = { getArticleById, getAllArticles };

--- a/endpoints.json
+++ b/endpoints.json
@@ -15,13 +15,14 @@
     "exampleResponse": {
       "articles": [
         {
-          "title": "Seafood substitutions are increasing",
-          "topic": "cooking",
-          "author": "weegembump",
-          "body": "Text from the article..",
-          "created_at": "2018-05-30T15:59:13.341Z",
+          "author": "rogersop",
+          "title": "UNCOVERED: catspiracy to bring down democracy",
+          "article_id": 5,
+          "topic": "cats",
+          "created_at": "2020-08-03T13:14:00.000Z",
           "votes": 0,
-          "comment_count": 6
+          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          "comment_count": 2
         }
       ]
     }

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -11,4 +11,34 @@ function selectArticleById(article_id) {
     });
 }
 
-module.exports = { selectArticleById };
+function selectAllArticles() {
+  return db
+    .query(
+      `
+    SELECT
+      articles.author,
+      articles.title,
+      articles.article_id,
+      articles.topic,
+      articles.created_at,
+      articles.votes,
+      articles.article_img_url,
+      CAST(COUNT(comments.comment_id) AS INT) AS comment_count -- force to integer, otherwise returns as string in object
+    FROM articles
+    LEFT JOIN comments ON comments.article_id = articles.article_id
+    GROUP BY
+      articles.author,
+      articles.title,
+      articles.article_id,
+      articles.topic,
+      articles.created_at,
+      articles.votes,
+      articles.article_img_url
+    ORDER BY 
+      articles.created_at DESC
+    `
+    )
+    .then((results) => results.rows);
+}
+
+module.exports = { selectArticleById, selectAllArticles };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "husky": "^8.0.2",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
+        "jest-sorted": "^1.0.15",
         "pg-format": "^1.0.4"
       }
     },
@@ -3257,6 +3258,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -7567,6 +7575,12 @@
           }
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==",
+      "dev": true
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "husky": "^8.0.2",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "jest-sorted": "^1.0.15",
     "pg-format": "^1.0.4"
   },
   "dependencies": {
@@ -34,7 +35,8 @@
   },
   "jest": {
     "setupFilesAfterEnv": [
-      "jest-extended/all"
+      "jest-extended/all",
+      "jest-sorted"
     ]
   }
 }


### PR DESCRIPTION
Added test for `GET`: `200` on `/api/articles` to get all articles sorted by `created_at` descending along with a count of comments.

- created new `controller` and `model` methods
- installed `jest-sorted` npm package
- updated example in `endpoints.json` for the endpoint