### PR TITLE
add GET /api/articles/:article_id/comments to get comments for a specified article_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -106,3 +106,40 @@ describe("/api/articles", () => {
       });
   });
 });
+
+describe("/api/articles/:article_id/comments", () => {
+  test("GET: 200 - respond with an array of comments for the given article_id ordered by the most recent comment first", () => {
+    return request(app)
+      .get("/api/articles/1/comments")
+      .expect(200)
+      .then(({ body: { comments } }) => {
+        expect(comments).toHaveLength(11);
+        comments.forEach((comment) =>
+          expect(comment).toMatchObject({
+            comment_id: expect.any(Number),
+            votes: expect.any(Number),
+            created_at: expect.any(String),
+            author: expect.any(String),
+            body: expect.any(String),
+            article_id: 1,
+          })
+        );
+
+        expect(comments).toBeSortedBy("created_at", { descending: true });
+      });
+  });
+
+  test("GET: 404 - respond with message 'Not found' when the specified article_id is not found", () => {
+    return request(app)
+      .get("/api/articles/9999/comments")
+      .expect(404)
+      .then(({ body: { msg } }) => expect(msg).toBe("Not found"));
+  });
+
+  test('GET: 400 - respond with message "Bad request" when the specified article_id is not the correct data type', () => {
+    return request(app)
+      .get("/api/articles/not-a-number/comments")
+      .expect(400)
+      .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
+  });
+});

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const {
   getArticleById,
   getAllArticles,
 } = require("./controllers/articles.controller");
+const { getCommentsByArticleId } = require("./controllers/comments.controller");
 const { getEndpoints } = require("./controllers/endpoints.controller");
 const { getTopics } = require("./controllers/topics.controller");
 
@@ -26,6 +27,8 @@ app.get("/api/topics", getTopics);
 app.get("/api/articles/:article_id", getArticleById);
 
 app.get("/api/articles", getAllArticles);
+
+app.get("/api/articles/:article_id/comments", getCommentsByArticleId);
 
 /**********************************************
  * Error handlers

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -1,9 +1,13 @@
+const { selectArticleById } = require("../models/articles.model");
+
 const { selectCommentsByArticleId } = require("../models/comments.model");
 
 function getCommentsByArticleId(request, response, next) {
   const { article_id } = request.params;
 
-  return selectCommentsByArticleId(article_id)
+  // test whether the article exists first
+  return selectArticleById(article_id)
+    .then((article) => selectCommentsByArticleId(article.article_id))
     .then((comments) => response.status(200).send({ comments: comments }))
     .catch(next);
 }

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -1,0 +1,11 @@
+const { selectCommentsByArticleId } = require("../models/comments.model");
+
+function getCommentsByArticleId(request, response, next) {
+  const { article_id } = request.params;
+
+  return selectCommentsByArticleId(article_id)
+    .then((comments) => response.status(200).send({ comments: comments }))
+    .catch(next);
+}
+
+module.exports = { getCommentsByArticleId };

--- a/endpoints.json
+++ b/endpoints.json
@@ -28,7 +28,7 @@
     }
   },
   "GET /api/articles/:article_id": {
-    "description": "serves an object corresponding to the specified article_id parameter",
+    "description": "serves an article object for the given article_id",
     "queries": [],
     "exampleResponse": {
       "article": {
@@ -41,6 +41,23 @@
         "votes": 0,
         "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
       }
+    }
+  },
+
+  "GET /api/articles/:article_id/comments": {
+    "description": "servces an array of comments for the given article_id ordered by the most recent comment first",
+    "queries": [],
+    "exampleResponse": {
+      "comments": [
+        {
+          "comment_id": 5,
+          "votes": 0,
+          "created_at": "2020-11-03T21:00:00.000Z",
+          "author": "icellusedkars",
+          "body": "I hate streaming noses",
+          "article_id": 1
+        }
+      ]
     }
   }
 }

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -1,9 +1,10 @@
 const db = require("../db/connection");
 
 function selectCommentsByArticleId(article_id) {
-  return db
-    .query(
-      `
+  return (
+    db
+      .query(
+        `
     SELECT
       comment_id,
       votes,
@@ -15,14 +16,13 @@ function selectCommentsByArticleId(article_id) {
     WHERE article_id = $1
     ORDER BY created_at DESC
     `,
-      [article_id]
-    )
-    .then((results) => {
-      if (!results.rowCount)
-        return Promise.reject({ status_code: 404, msg: "Not found" });
-
-      return results.rows;
-    });
+        [article_id]
+      )
+      // N.B. no need to test for empty rows as it is valid for no comments
+      // to be attached to an article. We can assume that article_id has been
+      // validated by controller before we query the database
+      .then((results) => results.rows)
+  );
 }
 
 module.exports = { selectCommentsByArticleId };

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -1,0 +1,28 @@
+const db = require("../db/connection");
+
+function selectCommentsByArticleId(article_id) {
+  return db
+    .query(
+      `
+    SELECT
+      comment_id,
+      votes,
+      created_at,
+      author,
+      body,
+      article_id
+    FROM comments
+    WHERE article_id = $1
+    ORDER BY created_at DESC
+    `,
+      [article_id]
+    )
+    .then((results) => {
+      if (!results.rowCount)
+        return Promise.reject({ status_code: 404, msg: "Not found" });
+
+      return results.rows;
+    });
+}
+
+module.exports = { selectCommentsByArticleId };


### PR DESCRIPTION
Added  endpoint `/api/articles/:article_id/comments` to get all comments for a specified `article_id` sorted by newest comments first.

- Tested for:
  - `GET`: `200` - successfully get all comments for the specified `article_id`
  - `GET`: `404` - the specified `article_id` does not exist
  - `GET`: `400` - the specified `article_id` is not in the expected format

- created new `controller` and `model` functions
- updated `endpoints.json` to include new endpoint

**Note:** 
It is a valid scenario that an `article` has no `comments`. Therefore, the controller function, `getCommentsByArticleId()`, first checks for a valid `article_id` before calling `selectCommentsByArticleId()`. If the `article_id` _is_ invalid, the error is caught and handled by the promise chain.

It is important that this is handled by the controller as the usual check for zero rows within the model function would not make sense in this case, and could incorrectly result in a `404` 'Not found'.