### PR TITLE
add POST /api/articles/:article_id/comments endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env.*
+scrap.*

--- a/app.js
+++ b/app.js
@@ -4,7 +4,10 @@ const {
   getArticleById,
   getAllArticles,
 } = require("./controllers/articles.controller");
-const { getCommentsByArticleId } = require("./controllers/comments.controller");
+const {
+  getCommentsByArticleId,
+  postNewComment,
+} = require("./controllers/comments.controller");
 const { getEndpoints } = require("./controllers/endpoints.controller");
 const { getTopics } = require("./controllers/topics.controller");
 
@@ -16,6 +19,8 @@ const {
 } = require("./error-handlers");
 
 const app = express();
+
+app.use(express.json());
 
 /**********************************************
  * GET methods
@@ -31,15 +36,20 @@ app.get("/api/articles", getAllArticles);
 app.get("/api/articles/:article_id/comments", getCommentsByArticleId);
 
 /**********************************************
+ * POST methods
+ **********************************************/
+app.post("/api/articles/:article_id/comments", postNewComment);
+
+/**********************************************
  * Error handlers
  **********************************************/
 // invalid endpoint
 app.all("*", badPathsErrorHandler);
 
-// handle custom error e.g. manually thrown 404 ('Not found')
+// handle custom, manually thrown errors
 app.use(customErrorHandler);
 
-// handle errors thrown by PSQL queries e.g. 400 ('Bad request')
+// handle errors thrown by PSQL queries
 app.use(psqlErrorHandler);
 
 // default, catch-all handler

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -1,6 +1,8 @@
 const { selectArticleById } = require("../models/articles.model");
-
-const { selectCommentsByArticleId } = require("../models/comments.model");
+const {
+  selectCommentsByArticleId,
+  insertNewComment,
+} = require("../models/comments.model");
 
 function getCommentsByArticleId(request, response, next) {
   const { article_id } = request.params;
@@ -12,4 +14,18 @@ function getCommentsByArticleId(request, response, next) {
     .catch(next);
 }
 
-module.exports = { getCommentsByArticleId };
+function postNewComment(request, response, next) {
+  const { article_id } = request.params;
+
+  const promises = [
+    insertNewComment(request.body, article_id),
+    selectArticleById(article_id),
+  ];
+
+  return Promise.all(promises)
+    .then((results) => {
+      response.status(201).send({ newComment: results[0] });
+    })
+    .catch(next);
+}
+module.exports = { getCommentsByArticleId, postNewComment };

--- a/endpoints.json
+++ b/endpoints.json
@@ -45,7 +45,7 @@
   },
 
   "GET /api/articles/:article_id/comments": {
-    "description": "servces an array of comments for the given article_id ordered by the most recent comment first",
+    "description": "serves an array of comments for the given article_id ordered by the most recent comment first",
     "queries": [],
     "exampleResponse": {
       "comments": [
@@ -58,6 +58,21 @@
           "article_id": 1
         }
       ]
+    }
+  },
+
+  "POST /api/articles/:article_id/comments": {
+    "description": "add a new comment to an article, returns with the newly posted comment",
+    "queries": [],
+    "exampleResponse": {
+      "newComment": {
+        "comment_id": 19,
+        "body": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet sapien vitae nibh convallis mollis. Donec feugiat elit eu enim gravida imperdiet.",
+        "article_id": 1,
+        "author": "lurker",
+        "votes": 0,
+        "created_at": "2024-10-15T11:28:08.445Z"
+      }
     }
   }
 }

--- a/error-handlers.js
+++ b/error-handlers.js
@@ -11,12 +11,16 @@ function customErrorHandler(error, request, response, next) {
 function psqlErrorHandler(error, request, response, next) {
   if (error.code) {
     switch (error.code) {
-      case "22P02":
+      case "22P02": // wrong data type
+      case "23502": // not-null violations
         return response.status(400).send({ msg: "Bad request" });
+
+      case "23503": // constraint violations
+        return response.status(404).send({ msg: "Not found" });
     }
   } else next(error);
 }
-function defaultErrorHandler(error, request, response) {
+function defaultErrorHandler(error, request, response, next) {
   response.status(500).send({ msg: "Internal server error" });
 }
 

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -1,4 +1,5 @@
 const db = require("../db/connection");
+const format = require("pg-format");
 
 function selectCommentsByArticleId(article_id) {
   return (
@@ -25,4 +26,21 @@ function selectCommentsByArticleId(article_id) {
   );
 }
 
-module.exports = { selectCommentsByArticleId };
+function insertNewComment(newComment, article_id) {
+  const insertValues = [[newComment.body, article_id, newComment.author]];
+
+  return db
+    .query(
+      format(
+        `
+      INSERT INTO comments(body, article_id, author) 
+      VALUES %L 
+      RETURNING *`,
+        insertValues
+      )
+    )
+    .then((results) => {
+      return results.rows[0];
+    });
+}
+module.exports = { selectCommentsByArticleId, insertNewComment };


### PR DESCRIPTION
Added ability to `POST` new comment, returns with newly posted comment when successful.

- Tested the following:
  - `201` - successfully posted new comment
  - `400` - "Bad request" when the sent `request.body` is incomplete
  - `404` - "Not found" when the specified `author` does not exist
  - `404` - "Not found" when the specified `article_id` does not exit

- Added corresponding `controller` and `model` functions
- Updated `PSQL error handler` to accommodate new PSQL error codes received
- Updated `endpoints.json` file with details for the endpoint