### PR TITLE
add PATCH /api/articles/:article_id endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ const express = require("express");
 const {
   getArticleById,
   getAllArticles,
+  patchArticleById,
 } = require("./controllers/articles.controller");
 const {
   getCommentsByArticleId,
@@ -39,6 +40,11 @@ app.get("/api/articles/:article_id/comments", getCommentsByArticleId);
  * POST methods
  **********************************************/
 app.post("/api/articles/:article_id/comments", postNewComment);
+
+/**********************************************
+ * PATCH methods
+ **********************************************/
+app.patch("/api/articles/:article_id", patchArticleById);
 
 /**********************************************
  * Error handlers

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,6 +1,7 @@
 const {
   selectArticleById,
   selectAllArticles,
+  updateArticleById,
 } = require("../models/articles.model");
 
 function getArticleById(request, response, next) {
@@ -16,4 +17,25 @@ function getAllArticles(request, response, next) {
     .then((rows) => response.status(200).send({ articles: rows }))
     .catch(next);
 }
-module.exports = { getArticleById, getAllArticles };
+
+function patchArticleById(request, response, next) {
+  const { article_id } = request.params;
+
+  // check that the request body includes the expected key
+  if (!Object.keys(request.body).includes("inc_votes")) {
+    return response.status(400).send({ status_code: 400, msg: "Bad request" });
+  }
+
+  // check that the article exists using Promise.all
+  const promises = [
+    updateArticleById(request.body, article_id),
+    selectArticleById(article_id),
+  ];
+
+  return Promise.all(promises)
+    .then((results) =>
+      response.status(200).send({ updatedArticle: results[0] })
+    )
+    .catch(next);
+}
+module.exports = { getArticleById, getAllArticles, patchArticleById };

--- a/endpoints.json
+++ b/endpoints.json
@@ -44,6 +44,23 @@
     }
   },
 
+  "PATCH /api/articles/:article_id": {
+    "description": "updates the number of votes for the given article_id",
+    "queries": [],
+    "exampleResponse": {
+      "updatedArticle": {
+        "article_id": 3,
+        "title": "Eight pug gifs that remind me of mitch",
+        "topic": "mitch",
+        "author": "icellusedkars",
+        "body": "some gifs",
+        "created_at": "2020-11-03T09:12:00.000Z",
+        "votes": 1,
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+      }
+    }
+  },
+
   "GET /api/articles/:article_id/comments": {
     "description": "serves an array of comments for the given article_id ordered by the most recent comment first",
     "queries": [],

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -41,4 +41,16 @@ function selectAllArticles() {
     .then((results) => results.rows);
 }
 
-module.exports = { selectArticleById, selectAllArticles };
+function updateArticleById(votes, article_id) {
+  return db
+    .query(
+      `
+    UPDATE articles
+    SET votes = GREATEST(votes + $1, 0) -- set to 0 if it goes negative
+    WHERE article_id = $2
+    RETURNING *`,
+      [votes.inc_votes, article_id]
+    )
+    .then((results) => results.rows[0]);
+}
+module.exports = { selectArticleById, selectAllArticles, updateArticleById };


### PR DESCRIPTION
Add ability to update the number of `votes` for a specified `article_id`.

- Tested the following:
  - `200` - successfully update the article by _increasing_ the number of `votes`
  - `200` - successfully update the article by _decreasing_ the number of `votes`
  - `200` - ensure `votes` does not go negative when decreasing
  - `200` - extra keys passed in the `request.body` are ignored
  - `400` - "Bad request" when the specified `article_id` is not the correct data type
  - `400` - "Bad Request" when `request.body` does not have the expected key or the wrong data type is provided
  - `404` - "Not found" when the specified `article_id` is not found

- Added corresponding `controller` and `model` functions.
- Refactored test script. Changed `beforeAll()` to `beforeEach()` to fix issue when updating the same record in consecutive tests.
- Updated `endpoints.json` with details for the endpoint.