### PR TITLE
add DELETE /api/comments/:comment_id endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -47,7 +47,7 @@ describe("/api/topics", () => {
 });
 
 describe("/api/articles/:article_id", () => {
-  describe("GET methods", () => {
+  describe("GET", () => {
     test("GET: 200 - respond with an article object for the specified article_id", () => {
       return request(app)
         .get("/api/articles/5")
@@ -82,7 +82,7 @@ describe("/api/articles/:article_id", () => {
     });
   });
 
-  describe("PATCH methods", () => {
+  describe("PATCH", () => {
     test("PATCH: 200 - update the specified article, increasing the votes and respond with an object representing the updated article", () => {
       const input = { inc_votes: 1 };
 
@@ -203,7 +203,7 @@ describe("/api/articles", () => {
 });
 
 describe("/api/articles/:article_id/comments", () => {
-  describe("GET methods", () => {
+  describe("GET", () => {
     test("GET: 200 - respond with an array of comments ordered by the most recent comment first when given a valid article_id that has comments", () => {
       return request(app)
         .get("/api/articles/1/comments")
@@ -249,7 +249,7 @@ describe("/api/articles/:article_id/comments", () => {
     });
   });
 
-  describe("POST methods", () => {
+  describe("POST", () => {
     test("POST: 201 - add a new comment for the specified article_id and respond with an object representing the posted comment", () => {
       const input = {
         body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet sapien vitae nibh convallis mollis. Donec feugiat elit eu enim gravida imperdiet.",
@@ -318,6 +318,35 @@ describe("/api/articles/:article_id/comments", () => {
         .then(({ body: { msg } }) => {
           expect(msg).toBe("Not found");
         });
+    });
+  });
+});
+
+describe("/api/comments/:comment_id", () => {
+  describe("DELETE", () => {
+    test("DELETE: 204 - respond with status code of 204 with no content on successfully deleting a comment", () => {
+      const comment_id = 5;
+      return request(app)
+        .delete(`/api/comments/${comment_id}`)
+        .expect(204)
+        .then(() =>
+          // request GET to check we get a 404 after deleting
+          request(app).get(`/api/comments/${comment_id}`).expect(404)
+        );
+    });
+
+    test('DELETE: 400 - respond with message "Bad request" when the specified comment_id is not the correct data type', () => {
+      return request(app)
+        .delete("/api/comments/not-a-number")
+        .expect(400)
+        .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
+    });
+
+    test('DELETE: 404 - respond with message "Not found" when the specified comment_id is not found in database', () => {
+      return request(app)
+        .delete("/api/comments/9999")
+        .expect(404)
+        .then(({ body: { msg } }) => expect(msg).toBe("Not found"));
     });
   });
 });

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const {
 const {
   getCommentsByArticleId,
   postNewComment,
+  removeCommentByCommentId,
 } = require("./controllers/comments.controller");
 const { getEndpoints } = require("./controllers/endpoints.controller");
 const { getTopics } = require("./controllers/topics.controller");
@@ -45,6 +46,11 @@ app.post("/api/articles/:article_id/comments", postNewComment);
  * PATCH methods
  **********************************************/
 app.patch("/api/articles/:article_id", patchArticleById);
+
+/**********************************************
+ * DELETE methods
+ **********************************************/
+app.delete("/api/comments/:comment_id", removeCommentByCommentId);
 
 /**********************************************
  * Error handlers

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -2,6 +2,8 @@ const { selectArticleById } = require("../models/articles.model");
 const {
   selectCommentsByArticleId,
   insertNewComment,
+  selectCommentByCommentId,
+  deleteCommentByCommentId,
 } = require("../models/comments.model");
 
 function getCommentsByArticleId(request, response, next) {
@@ -28,4 +30,19 @@ function postNewComment(request, response, next) {
     })
     .catch(next);
 }
-module.exports = { getCommentsByArticleId, postNewComment };
+
+function removeCommentByCommentId(request, response, next) {
+  const { comment_id } = request.params;
+
+  // check the comment exists first
+  return selectCommentByCommentId(comment_id)
+    .then(() => deleteCommentByCommentId(comment_id))
+    .then(() => response.status(204).send())
+    .catch(next);
+}
+
+module.exports = {
+  getCommentsByArticleId,
+  postNewComment,
+  removeCommentByCommentId,
+};

--- a/endpoints.json
+++ b/endpoints.json
@@ -91,5 +91,11 @@
         "created_at": "2024-10-15T11:28:08.445Z"
       }
     }
+  },
+
+  "DELETE /api/comments/:comment_id": {
+    "description": "deletes the specified comment",
+    "queries": [],
+    "exampleResponse": "No response content is returned on successful delete"
   }
 }

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -43,4 +43,24 @@ function insertNewComment(newComment, article_id) {
       return results.rows[0];
     });
 }
-module.exports = { selectCommentsByArticleId, insertNewComment };
+
+function selectCommentByCommentId(comment_id) {
+  return db
+    .query("SELECT * FROM comments WHERE comment_id = $1", [comment_id])
+    .then((results) => {
+      if (!results.rowCount)
+        return Promise.reject({ status_code: 404, msg: "Not found" });
+
+      return results.rows[0];
+    });
+}
+function deleteCommentByCommentId(comment_id) {
+  return db.query("DELETE FROM comments WHERE comment_id = $1", [comment_id]);
+}
+
+module.exports = {
+  selectCommentsByArticleId,
+  insertNewComment,
+  selectCommentByCommentId,
+  deleteCommentByCommentId,
+};


### PR DESCRIPTION
Add ability to delete the comment specified by `comment_id`.

- Tested the following:
  -  `204` - successfully delete the comment
  -  `400` - "Bad request" when the specified `comment_id` is not the correct data type
  - `404` - "Not found" when the specified `comment_id` is not found in database

- Added corresponding `controller` and `model` functions.
- Updated `endpoints.json` with details for the endpoint.