### PR TITLE
add sorting queries to GET /api/articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -177,28 +177,64 @@ describe("/api/articles/:article_id", () => {
 });
 
 describe("/api/articles", () => {
-  test("GET: 200 - respond with an array of all article objects sorted by date in descending order", () => {
-    return request(app)
-      .get("/api/articles")
-      .expect(200)
-      .then(({ body: { articles } }) => {
-        expect(articles).toHaveLength(13);
+  describe("GET", () => {
+    test("GET: 200 - respond with an array of all article objects sorted by date in descending order", () => {
+      return request(app)
+        .get("/api/articles")
+        .expect(200)
+        .then(({ body: { articles } }) => {
+          expect(articles).toHaveLength(13);
 
-        articles.forEach((article) => {
-          expect(article).toMatchObject({
-            author: expect.any(String),
-            title: expect.any(String),
-            article_id: expect.any(Number),
-            topic: expect.any(String),
-            created_at: expect.any(String),
-            votes: expect.any(Number),
-            article_img_url: expect.any(String),
-            comment_count: expect.any(Number),
+          articles.forEach((article) => {
+            expect(article).toMatchObject({
+              author: expect.any(String),
+              title: expect.any(String),
+              article_id: expect.any(Number),
+              topic: expect.any(String),
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              article_img_url: expect.any(String),
+              comment_count: expect.any(Number),
+            });
           });
-        });
 
-        expect(articles).toBeSortedBy("created_at", { descending: true });
-      });
+          expect(articles).toBeSortedBy("created_at", { descending: true });
+        });
+    });
+  });
+
+  describe("Queries", () => {
+    test("GET: 200 - respond with an array of all article objects sorted by the specified column and in ascending order", () => {
+      return request(app)
+        .get("/api/articles?sort_by=author&order=asc")
+        .expect(200)
+        .then(({ body: { articles } }) => {
+          expect(articles).toBeSortedBy("author");
+        });
+    });
+
+    test("GET: 200 - respond with an array of all article objects sorted by the specified column and in descending order", () => {
+      return request(app)
+        .get("/api/articles?sort_by=topic&order=desc")
+        .expect(200)
+        .then(({ body: { articles } }) => {
+          expect(articles).toBeSortedBy("topic", { descending: true });
+        });
+    });
+
+    test('GET: 400 - respond with message "Bad request" when attempting to sort by a disallowed column', () => {
+      return request(app)
+        .get("/api/articles?sort_by=disallowed-column-name&order=desc")
+        .expect(400)
+        .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
+    });
+
+    test('GET: 400 - respond with message "Bad request" when attempting to order by an invalid value', () => {
+      return request(app)
+        .get("/api/articles?sort_by=author&order=invalid")
+        .expect(400)
+        .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
+    });
   });
 });
 

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ const express = require("express");
 
 const {
   getArticleById,
-  getAllArticles,
+  getArticles,
   patchArticleById,
 } = require("./controllers/articles.controller");
 const {
@@ -34,7 +34,7 @@ app.get("/api/topics", getTopics);
 
 app.get("/api/articles/:article_id", getArticleById);
 
-app.get("/api/articles", getAllArticles);
+app.get("/api/articles", getArticles);
 
 app.get("/api/articles/:article_id/comments", getCommentsByArticleId);
 

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,6 +1,6 @@
 const {
   selectArticleById,
-  selectAllArticles,
+  selectArticles,
   updateArticleById,
 } = require("../models/articles.model");
 
@@ -12,8 +12,10 @@ function getArticleById(request, response, next) {
     .catch(next);
 }
 
-function getAllArticles(request, response, next) {
-  return selectAllArticles()
+function getArticles(request, response, next) {
+  const { sort_by, order } = request.query;
+
+  return selectArticles(sort_by, order)
     .then((rows) => response.status(200).send({ articles: rows }))
     .catch(next);
 }
@@ -38,4 +40,4 @@ function patchArticleById(request, response, next) {
     )
     .catch(next);
 }
-module.exports = { getArticleById, getAllArticles, patchArticleById };
+module.exports = { getArticleById, getArticles, patchArticleById };

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -11,7 +11,24 @@ function selectArticleById(article_id) {
     });
 }
 
-function selectAllArticles() {
+function selectArticles(sort_by = "created_at", order = "desc") {
+  const allowedSortBy = [
+    "author",
+    "title",
+    "article_id",
+    "topic",
+    "created_at",
+    "votes",
+    "article_img_url",
+    "comment_count",
+  ];
+
+  const allowedOrders = ["asc", "desc"];
+
+  if (!allowedSortBy.includes(sort_by) || !allowedOrders.includes(order)) {
+    return Promise.reject({ status_code: 400, msg: "Bad request" });
+  }
+
   return db
     .query(
       `
@@ -35,7 +52,7 @@ function selectAllArticles() {
       articles.votes,
       articles.article_img_url
     ORDER BY 
-      articles.created_at DESC
+      ${sort_by} ${order}
     `
     )
     .then((results) => results.rows);
@@ -53,4 +70,4 @@ function updateArticleById(votes, article_id) {
     )
     .then((results) => results.rows[0]);
 }
-module.exports = { selectArticleById, selectAllArticles, updateArticleById };
+module.exports = { selectArticleById, selectArticles, updateArticleById };


### PR DESCRIPTION
Add ability to provide sorting queries for `GET` `/api/articles`.

- `sort_by` - any column returned by `GET` is valid, defaults to `created_at`
- `order` - either `asc` or `desc`, defaults to `desc`

Any other values for either field will result in a `400` "Bad request".

- Tested the following:
  - `200` - sort articles in ascending order
  - `200` - sort articles in descending order
  - `400` - "Bad request" when an invalid `sort_by` value is provided
  - `400` - "Bad request" when an invalid `order` value is provided

- Renamed the following to match established naming convention:
  - `controller` function `getAllArticles` to `getArticles`
  - `model` function `selectAllArticles` to `selectArticles`
