### PR TITLE
add ability to filter GET /api/articles using a "topic" query

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -181,7 +181,7 @@ describe("/api/articles", () => {
     });
   });
 
-  describe("Queries", () => {
+  describe("Sorting queries", () => {
     test("GET: 200 - respond with an array of all article objects sorted by the specified column and in ascending order", () => {
       return request(app)
         .get("/api/articles?sort_by=author&order=asc")
@@ -212,6 +212,43 @@ describe("/api/articles", () => {
         .get("/api/articles?sort_by=author&order=invalid")
         .expect(400)
         .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
+    });
+  });
+
+  describe("Topic query", () => {
+    test("GET: 200 - respond with an array of all article objects when filtered by a existing topic", () => {
+      const topic = "mitch";
+
+      return request(app)
+        .get(`/api/articles?topic=${topic}`)
+        .expect(200)
+        .then(({ body: { articles } }) => {
+          expect(articles).toHaveLength(12);
+          articles.forEach((article) =>
+            expect(article).toMatchObject({
+              author: expect.any(String),
+              title: expect.any(String),
+              article_id: expect.any(Number),
+              topic: topic,
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              article_img_url: expect.any(String),
+              comment_count: expect.any(Number),
+            })
+          );
+        });
+    });
+
+    test("GET: 200 - respond with an empty array when filtered by a non-existent topic", () => {
+      const topic = "non-existent-topic";
+
+      return request(app)
+        .get(`/api/articles?topic=${topic}`)
+        .expect(200)
+        .then(({ body: { articles } }) => {
+          expect(Array.isArray(articles)).toBe(true);
+          expect(articles).toHaveLength(0);
+        });
     });
   });
 });

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -13,9 +13,9 @@ function getArticleById(request, response, next) {
 }
 
 function getArticles(request, response, next) {
-  const { sort_by, order } = request.query;
+  const { sort_by, order, topic } = request.query;
 
-  return selectArticles(sort_by, order)
+  return selectArticles(sort_by, order, topic)
     .then((articles) => response.status(200).send({ articles }))
     .catch(next);
 }

--- a/error-handlers.js
+++ b/error-handlers.js
@@ -14,9 +14,12 @@ function psqlErrorHandler(error, request, response, next) {
       case "22P02": // wrong data type
       case "23502": // not-null violations
         return response.status(400).send({ msg: "Bad request" });
-
       case "23503": // constraint violations
         return response.status(404).send({ msg: "Not found" });
+      default:
+        return response
+          .status(500)
+          .send({ msg: `Database error, code: ${error.code}` });
     }
   } else next(error);
 }


### PR DESCRIPTION
- Tested:
  - `200` - return array when filtering by an existing `topic`
  - `200` - return empty array when filtering by a non-existent `topic`

- fixed issue with `psqlErrorHandler` function where an un-handled PSQL error was causing the application to hang.