### PR TITLE
add comment_count to GET /api/articles/:article_id endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -48,13 +48,15 @@ describe("/api/topics", () => {
 
 describe("/api/articles/:article_id", () => {
   describe("GET", () => {
-    test("GET: 200 - respond with an article object for the specified article_id", () => {
+    test("GET: 200 - respond with an article object for the specified article_id (when article has comments)", () => {
+      const article_id = 5;
+
       return request(app)
-        .get("/api/articles/5")
+        .get(`/api/articles/${article_id}`)
         .expect(200)
         .then(({ body: { article } }) => {
           expect(article).toMatchObject({
-            article_id: 5,
+            article_id: article_id,
             title: "UNCOVERED: catspiracy to bring down democracy",
             topic: "cats",
             author: "rogersop",
@@ -63,6 +65,29 @@ describe("/api/articles/:article_id", () => {
             votes: 0,
             article_img_url:
               "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+            comment_count: 2,
+          });
+        });
+    });
+
+    test("GET: 200 - respond with an article object for the specified article_id (when article has no comments)", () => {
+      const article_id = 2;
+
+      return request(app)
+        .get(`/api/articles/${article_id}`)
+        .expect(200)
+        .then(({ body: { article } }) => {
+          expect(article).toMatchObject({
+            article_id: article_id,
+            title: "Sony Vaio; or, The Laptop",
+            topic: "mitch",
+            author: "icellusedkars",
+            body: "Call me Mitchell. Some years ago—never mind how long precisely—having little or no money in my purse, and nothing particular to interest me on shore, I thought I would buy a laptop about a little and see the codey part of the world. It is a way I have of driving off the spleen and regulating the circulation. Whenever I find myself growing grim about the mouth; whenever it is a damp, drizzly November in my soul; whenever I find myself involuntarily pausing before coffin warehouses, and bringing up the rear of every funeral I meet; and especially whenever my hypos get such an upper hand of me, that it requires a strong moral principle to prevent me from deliberately stepping into the street, and methodically knocking people’s hats off—then, I account it high time to get to coding as soon as I can. This is my substitute for pistol and ball. With a philosophical flourish Cato throws himself upon his sword; I quietly take to the laptop. There is nothing surprising in this. If they but knew it, almost all men in their degree, some time or other, cherish very nearly the same feelings towards the the Vaio with me.",
+            created_at: "2020-10-16T05:03:00.000Z",
+            votes: 0,
+            article_img_url:
+              "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+            comment_count: 0,
           });
         });
     });

--- a/endpoints.json
+++ b/endpoints.json
@@ -34,7 +34,8 @@
         "body": "Bastet walks amongst us, and the cats are taking arms!",
         "created_at": "2020-08-03T13:14:00.000Z",
         "votes": 0,
-        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+        "comment_count": 2
       }
     }
   },

--- a/error-handlers.js
+++ b/error-handlers.js
@@ -17,6 +17,8 @@ function psqlErrorHandler(error, request, response, next) {
       case "23503": // constraint violations
         return response.status(404).send({ msg: "Not found" });
       default:
+        console.log(error);
+
         return response
           .status(500)
           .send({ msg: `Database error, code: ${error.code}` });


### PR DESCRIPTION
Added `comment_count` key to returned `article` object  to `GET` `/api/articles/:article_id` endpoint.

- Tested:
  - `200` - when the specified `article_id` has comments, returns the number of existing comments
  - `200` - when the specified `article_id` has no comments, returns `0` for the number of comments

- Updated `endpoints.json` to include `comment_count` in the example output