### PR TITLE
refactor test for DELETE: 204; remove comment check

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -401,14 +401,7 @@ describe("/api/articles/:article_id/comments", () => {
 describe("/api/comments/:comment_id", () => {
   describe("DELETE", () => {
     test("DELETE: 204 - respond with status code of 204 with no content on successfully deleting a comment", () => {
-      const comment_id = 5;
-      return request(app)
-        .delete(`/api/comments/${comment_id}`)
-        .expect(204)
-        .then(() =>
-          // request GET to check we get a 404 after deleting
-          request(app).get(`/api/comments/${comment_id}`).expect(404)
-        );
+      return request(app).delete("/api/comments/5").expect(204);
     });
 
     test('DELETE: 400 - respond with message "Bad request" when the specified comment_id is not the correct data type', () => {
@@ -416,13 +409,6 @@ describe("/api/comments/:comment_id", () => {
         .delete("/api/comments/not-a-number")
         .expect(400)
         .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
-    });
-
-    test('DELETE: 404 - respond with message "Not found" when the specified comment_id is not found in database', () => {
-      return request(app)
-        .delete("/api/comments/9999")
-        .expect(404)
-        .then(({ body: { msg } }) => expect(msg).toBe("Not found"));
     });
   });
 });

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -34,9 +34,7 @@ function postNewComment(request, response, next) {
 function removeCommentByCommentId(request, response, next) {
   const { comment_id } = request.params;
 
-  // check the comment exists first
-  return selectCommentByCommentId(comment_id)
-    .then(() => deleteCommentByCommentId(comment_id))
+  return deleteCommentByCommentId(comment_id)
     .then(() => response.status(204).send())
     .catch(next);
 }


### PR DESCRIPTION
Addresses issue raised in https://github.com/dku7/be-nc-news/pull/12. 

- Refactored test script to remove `GET` request after deleting a comment
- Removed checking if a comment exists in the promise chain in the `removeCommentByCommentId` function. 
  - Due to this, it was no longer valid to check for a `404`
  - The database always completes successfully as long as the data type is valid
  - Therefore, a `204` is returned even if the `comment_id` does not exist
  - Removed testing for `404` from the test script