### PR TITLE
add GET /api/users/:username endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -433,3 +433,28 @@ describe("/api/users", () => {
     });
   });
 });
+
+describe("/api/users/:username", () => {
+  const username = "icellusedkars";
+
+  test("GET: 200 - respond with a user object for the specified username", () => {
+    return request(app)
+      .get(`/api/users/${username}`)
+      .expect(200)
+      .then(({ body: { user } }) =>
+        expect(user).toMatchObject({
+          username: username,
+          name: "sam",
+          avatar_url:
+            "https://avatars2.githubusercontent.com/u/24604688?s=460&v=4",
+        })
+      );
+  });
+
+  test('GET: 404 - respond with message "Not found" when the specified username is not found', () => {
+    return request(app)
+      .get("/api/users/user-does-not-exist")
+      .expect(404)
+      .then(({ body: { msg } }) => expect(msg).toBe("Not found"));
+  });
+});

--- a/controllers/users.controller.js
+++ b/controllers/users.controller.js
@@ -1,4 +1,4 @@
-const { selectUsers } = require("../models/users.model");
+const { selectUsers, selectUserByUsername } = require("../models/users.model");
 
 function getUsers(request, response, next) {
   return selectUsers()
@@ -6,4 +6,12 @@ function getUsers(request, response, next) {
     .catch(next);
 }
 
-module.exports = { getUsers };
+function getUserByUsername(request, response, next) {
+  const { username } = request.params;
+
+  return selectUserByUsername(username)
+    .then((user) => response.status(200).send({ user }))
+    .catch(next);
+}
+
+module.exports = { getUsers, getUserByUsername };

--- a/endpoints.json
+++ b/endpoints.json
@@ -79,6 +79,20 @@
     }
   },
 
+  "GET /api/users/:username": {
+    "description": "serves a user object for the given username",
+    "queries": [],
+    "exampleResponse": {
+      "user": [
+        {
+          "username": "butter_bridge",
+          "name": "jonny",
+          "avatar_url": "https://www.healthytherapies.com/wp-content/uploads/2016/06/Lime3.jpg"
+        }
+      ]
+    }
+  },
+
   "DELETE /api/comments/:comment_id": {
     "description": "deletes the specified comment",
     "queries": [],

--- a/models/users.model.js
+++ b/models/users.model.js
@@ -6,4 +6,24 @@ function selectUsers() {
     .then((results) => results.rows);
 }
 
-module.exports = { selectUsers };
+function selectUserByUsername(username) {
+  return db
+    .query(
+      `
+    SELECT 
+      username, 
+      name, 
+      avatar_url 
+    FROM users
+    WHERE username = $1`,
+      [username]
+    )
+    .then((results) => {
+      if (!results.rowCount)
+        return Promise.reject({ status_code: 404, msg: "Not found" });
+
+      return results.rows[0];
+    });
+}
+
+module.exports = { selectUsers, selectUserByUsername };

--- a/routers/users.router.js
+++ b/routers/users.router.js
@@ -1,7 +1,13 @@
 const usersRouter = require("express").Router();
-const { getUsers } = require("../controllers/users.controller");
+const {
+  getUsers,
+  getUserByUsername,
+} = require("../controllers/users.controller");
 
 // handle requests for /api/users
 usersRouter.get("/", getUsers);
+
+// handle requests for /api/users/:username
+usersRouter.get("/:username", getUserByUsername);
 
 module.exports = usersRouter;


### PR DESCRIPTION
Add ability to `GET` a `user` object by `username`.

- Tested
  - `200` - successfully return the specified user
  - `404` - return error message "Not found" when `username` can not be found

- Created new `controller` and `model` functions
- Added new routing for the endpoint
- Updated `endpoints.json` file with details about the endpoint