### PR TITLE
add PATCH /api/comments/:comment_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -411,6 +411,68 @@ describe("/api/comments/:comment_id", () => {
         .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
     });
   });
+
+  describe("PATCH", () => {
+    test("PATCH: 200 - update the specified comment, increasing the votes and respond with an object representing the updated comment", () => {
+      const input = { inc_votes: 1 };
+      const comment_id = 3;
+
+      return request(app)
+        .patch(`/api/comments/${comment_id}`)
+        .send(input)
+        .expect(200)
+        .then(({ body: { updatedComment } }) => {
+          expect(updatedComment.comment_id).toBe(comment_id);
+          expect(updatedComment.votes).toBe(101);
+        });
+    });
+
+    test("PATCH: 200 - update the specified comment, decreasing the votes and respond with an object representing the updated comment", () => {
+      const input = { inc_votes: -3 };
+      const comment_id = 2;
+
+      return request(app)
+        .patch(`/api/comments/${comment_id}`)
+        .send(input)
+        .expect(200)
+        .then(({ body: { updatedComment } }) => {
+          expect(updatedComment.comment_id).toBe(comment_id);
+          expect(updatedComment.votes).toBe(11);
+        });
+    });
+
+    test('PATCH: 400 - respond with message "Bad request" when the specified comment_id is not the correct data type', () => {
+      const input = { inc_votes: 1 };
+
+      return request(app)
+        .patch("/api/comments/not-a-number")
+        .send(input)
+        .expect(400)
+        .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
+    });
+
+    test('PATCH: 400 - respond with message "Bad Request" when the wrong data type is provided for the patch', () => {
+      const input = { inc_votes: "this is a string not a number!" };
+
+      return request(app)
+        .patch("/api/comments/1")
+        .expect(400)
+        .send(input)
+        .then((result) => {
+          expect(result.body.msg).toBe("Bad request");
+        });
+    });
+
+    test("PATCH: 404 - respond with message 'Not found' when the specified comment_id is not found", () => {
+      const input = { inc_votes: 1 };
+
+      return request(app)
+        .patch("/api/comments/9999")
+        .send(input)
+        .expect(404)
+        .then(({ body: { msg } }) => expect(msg).toBe("Not found"));
+    });
+  });
 });
 
 describe("/api/users", () => {

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -4,6 +4,7 @@ const {
   insertNewComment,
   selectCommentByCommentId,
   deleteCommentByCommentId,
+  updateCommentByCommentId,
 } = require("../models/comments.model");
 
 function getCommentsByArticleId(request, response, next) {
@@ -39,8 +40,32 @@ function removeCommentByCommentId(request, response, next) {
     .catch(next);
 }
 
+function patchCommentByCommentId(request, response, next) {
+  const { comment_id } = request.params;
+
+  // check that the request body includes the expected key
+  if (!Object.keys(request.body).includes("inc_votes")) {
+    return response.status(400).send({ status_code: 400, msg: "Bad request" });
+  }
+
+  const { inc_votes } = request.body;
+
+  // check that the comment exists using Promise.all
+  const promises = [
+    updateCommentByCommentId(inc_votes, comment_id),
+    selectCommentByCommentId(comment_id),
+  ];
+
+  return Promise.all(promises)
+    .then((fulfilledPromises) =>
+      response.status(200).send({ updatedComment: fulfilledPromises[0] })
+    )
+    .catch(next);
+}
+
 module.exports = {
   getCommentsByArticleId,
   postNewComment,
   removeCommentByCommentId,
+  patchCommentByCommentId,
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -116,6 +116,23 @@
     }
   },
 
+  "PATCH /api/comments/:comment_id": {
+    "description": "updates the number of votes for the given comment_id",
+    "queries": [],
+    "exampleResponse": {
+      "comments": [
+        {
+          "comment_id": 5,
+          "votes": 1,
+          "created_at": "2020-11-03T21:00:00.000Z",
+          "author": "icellusedkars",
+          "body": "I hate streaming noses",
+          "article_id": 1
+        }
+      ]
+    }
+  },
+
   "POST /api/articles/:article_id/comments": {
     "description": "add a new comment to an article, returns with the newly posted comment",
     "queries": [],

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -58,9 +58,27 @@ function deleteCommentByCommentId(comment_id) {
   return db.query("DELETE FROM comments WHERE comment_id = $1", [comment_id]);
 }
 
+function updateCommentByCommentId(inc_votes, comment_id) {
+  // check inc_votes is a number
+  if (typeof inc_votes != "number")
+    return Promise.reject({ status_code: 400, msg: "Bad request" });
+
+  return db
+    .query(
+      `
+    UPDATE comments
+    SET votes = votes + $1
+    WHERE comment_id = $2
+    RETURNING *`,
+      [inc_votes, comment_id]
+    )
+    .then((results) => results.rows[0]);
+}
+
 module.exports = {
   selectCommentsByArticleId,
   insertNewComment,
   selectCommentByCommentId,
   deleteCommentByCommentId,
+  updateCommentByCommentId,
 };

--- a/routers/comments.router.js
+++ b/routers/comments.router.js
@@ -1,9 +1,13 @@
 const commentsRouter = require("express").Router();
 const {
   removeCommentByCommentId,
+  patchCommentByCommentId,
 } = require("../controllers/comments.controller");
 
 // handle requests for /api/comments/:comment_id
-commentsRouter.delete("/:comment_id", removeCommentByCommentId);
+commentsRouter
+  .route("/:comment_id")
+  .delete(removeCommentByCommentId)
+  .patch(patchCommentByCommentId);
 
 module.exports = commentsRouter;


### PR DESCRIPTION
Add `PATCH` method to `/api/comments/:comment_id` endpoint.

- Tested:
  - `200` - successfully increase the `votes` and respond with the updated comment
  - `200` - successfully decrease the `votes` and respond with the updated comment
  - `400` - "Bad request" when the specified `comment_id` is not the correct data type
  - `400` - "Bad Request" when the wrong data type is provided for the patch
  - `404` - "Not found" when the specified `comment_id` is not found

- Added corresponding `controller` and `model` functions
- Modified routing for endpoint
- Updated `endpoints.json` with details about the method/endpoint