### PR TITLE
add POST method for /api/articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -297,6 +297,82 @@ describe("/api/articles", () => {
         });
     });
   });
+
+  describe("POST", () => {
+    test("POST: 201 - add a new article and respond with an object representing the posted article", () => {
+      const input = {
+        author: "lurker",
+        title: "Lorem ipsum",
+        body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet sapien vitae nibh convallis mollis. Donec feugiat elit eu enim gravida imperdiet.",
+        topic: "cats",
+        article_img_url: "https://picsum.photos/200",
+      };
+
+      return request(app)
+        .post("/api/articles")
+        .send(input)
+        .expect(201)
+        .then(({ body: { newArticle } }) => {
+          expect(newArticle).toMatchObject({
+            article_id: 14,
+            title: "Lorem ipsum",
+            topic: "cats",
+            author: "lurker",
+            body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet sapien vitae nibh convallis mollis. Donec feugiat elit eu enim gravida imperdiet.",
+            created_at: expect.any(String),
+            votes: 0,
+            article_img_url: "https://picsum.photos/200",
+            comment_count: 0,
+          });
+        });
+    });
+
+    test('POST: 400 - respond with message "Bad request" when passed in object does not have the required keys', () => {
+      const input = {
+        author: "lurker",
+        title: "Lorem ipsum",
+        topic: "cats",
+      };
+
+      return request(app)
+        .post("/api/articles")
+        .send(input)
+        .expect(400)
+        .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
+    });
+
+    test('POST: 404 - respond with message "Not found" when the specified username does not exist', () => {
+      const input = {
+        author: "i-do-not-exist",
+        title: "Lorem ipsum",
+        body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet sapien vitae nibh convallis mollis. Donec feugiat elit eu enim gravida imperdiet.",
+        topic: "cats",
+        article_img_url: "https://picsum.photos/200",
+      };
+
+      return request(app)
+        .post("/api/articles")
+        .send(input)
+        .expect(404)
+        .then(({ body: { msg } }) => expect(msg).toBe("Not found"));
+    });
+
+    test('POST: 404 - respond with message "Not found" when the specified topic does not exist', () => {
+      const input = {
+        author: "lurker",
+        title: "Lorem ipsum",
+        body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet sapien vitae nibh convallis mollis. Donec feugiat elit eu enim gravida imperdiet.",
+        topic: "a-new-topic",
+        article_img_url: "https://picsum.photos/200",
+      };
+
+      return request(app)
+        .post("/api/articles")
+        .send(input)
+        .expect(404)
+        .then(({ body: { msg } }) => expect(msg).toBe("Not found"));
+    });
+  });
 });
 
 describe("/api/articles/:article_id/comments", () => {

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -2,6 +2,7 @@ const {
   selectArticleById,
   selectArticles,
   updateArticleById,
+  insertNewArticle,
 } = require("../models/articles.model");
 
 function getArticleById(request, response, next) {
@@ -42,4 +43,29 @@ function patchArticleById(request, response, next) {
     )
     .catch(next);
 }
-module.exports = { getArticleById, getArticles, patchArticleById };
+
+function postNewArticle(request, response, next) {
+  const minRequiredKeys = ["author", "title", "body", "topic"];
+  const requestedNewArticle = request.body;
+  const newArticleKeys = Object.keys(requestedNewArticle);
+
+  // check the requested new article has the required keys
+  if (
+    newArticleKeys.length < minRequiredKeys.length ||
+    !minRequiredKeys.every((key) => newArticleKeys.includes(key))
+  ) {
+    return response.status(400).send({ status_code: 400, msg: "Bad request" });
+  }
+
+  return insertNewArticle(requestedNewArticle)
+    .then((article_id) => selectArticleById(article_id))
+    .then((newArticle) => response.status(201).send({ newArticle }))
+    .catch(next);
+}
+
+module.exports = {
+  getArticleById,
+  getArticles,
+  patchArticleById,
+  postNewArticle,
+};

--- a/endpoints.json
+++ b/endpoints.json
@@ -133,6 +133,25 @@
     }
   },
 
+  "POST /api/articles": {
+    "description": "add a new article, returns with the newly posted article",
+    "queries": [],
+    "exampleResponse": {
+      "newArticle": [
+        {
+          "author": "rogersop",
+          "title": "UNCOVERED: catspiracy to bring down democracy",
+          "article_id": 5,
+          "topic": "cats",
+          "created_at": "2020-08-03T13:14:00.000Z",
+          "votes": 0,
+          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          "comment_count": 2
+        }
+      ]
+    }
+  },
+
   "POST /api/articles/:article_id/comments": {
     "description": "add a new comment to an article, returns with the newly posted comment",
     "queries": [],

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -1,4 +1,5 @@
 const db = require("../db/connection");
+const format = require("pg-format");
 
 function selectArticleById(article_id) {
   let queryString = `
@@ -97,4 +98,30 @@ function updateArticleById(inc_votes, article_id) {
     )
     .then((results) => results.rows[0]);
 }
-module.exports = { selectArticleById, selectArticles, updateArticleById };
+
+function insertNewArticle(newArticle) {
+  const insertValues = [];
+
+  for (key in newArticle) insertValues.push(newArticle[key]);
+
+  return db
+    .query(
+      format(
+        `INSERT INTO articles (
+          author,
+          title,
+          body,
+          topic,
+          article_img_url
+      ) VALUES %L RETURNING *`,
+        [insertValues]
+      )
+    )
+    .then((results) => results.rows[0].article_id);
+}
+module.exports = {
+  selectArticleById,
+  selectArticles,
+  updateArticleById,
+  insertNewArticle,
+};

--- a/routers/articles.router.js
+++ b/routers/articles.router.js
@@ -3,6 +3,7 @@ const {
   getArticleById,
   getArticles,
   patchArticleById,
+  postNewArticle,
 } = require("../controllers/articles.controller");
 
 const {
@@ -11,7 +12,7 @@ const {
 } = require("../controllers/comments.controller");
 
 // handle requests for /api/articles
-articlesRouter.get("/", getArticles);
+articlesRouter.route("/").get(getArticles).post(postNewArticle);
 
 // handle requests for /api/articles/:article_id
 articlesRouter


### PR DESCRIPTION
Add ability to add a new article returns the newly posted article.

- Tested:
  -  `201` - successfully add a new article
  - `400` - "Bad request" when passed in object does not have the required keys
  - `404` - "Not found" when the specified `username` does not exist
  - `404` - "Not found" when the specified `topic` does not exist

- Added new corresponding `controller` and `model` functions
- Modified routing for `/api/articles`
- Updated `endpoints.json` with details for the endpoint