### PR TITLE
add pagination query for GET /api/articles

### DIFF
--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -14,10 +14,19 @@ function getArticleById(request, response, next) {
 }
 
 function getArticles(request, response, next) {
-  const { sort_by, order, topic } = request.query;
+  const { sort_by, order, topic, limit, p } = request.query;
 
-  return selectArticles(sort_by, order, topic)
-    .then((articles) => response.status(200).send({ articles }))
+  // check limit and p are valid types and not negative
+  if ((limit && (isNaN(limit) || limit < 0)) || (p && (isNaN(p) || p < 0)))
+    return response.status(400).send({ status_code: 400, msg: "Bad request" });
+
+  return selectArticles(sort_by, order, topic, limit, p)
+    .then((articles) =>
+      response.status(200).send({
+        total_count: articles.length,
+        articles: articles,
+      })
+    )
     .catch(next);
 }
 

--- a/endpoints.json
+++ b/endpoints.json
@@ -5,8 +5,9 @@
 
   "GET /api/articles": {
     "description": "serves an array of all articles",
-    "queries": ["author", "topic", "sort_by", "order"],
+    "queries": ["author", "topic", "sort_by", "order", "limit", "p"],
     "exampleResponse": {
+      "total_count": 0,
       "articles": [
         {
           "author": "rogersop",


### PR DESCRIPTION
Add ability specify pagination queries for `/api/articles`.

- Tested:
  - `200` - respond with an array of article objects limited to 10 articles by default
  - `200` - respond with an array of articles limited by the specified `limit`
  - `200` - respond with an array of articles limited by the specified `limit` and page (`p`)
  - `200` - respond with a `total_count` property, displaying the total number of articles returned
  - `400` - "Bad request" when specified `limit` is not a number
  - `400` - "Bad request" when specified `p` is not a number
  - `400` - "Bad request" when specified `limit` is negative
  - `400` - "Bad request" when specified `p` is negative

- Fixed previous tests which failed because they were asserting against an expected number of articles being returned
- Modified corresponding `controller` and `model` functions
- Updated `endpoints.json` with the additional `limit` and 'p` query options
