### PR TITLE
add pagination query options for GET /api/articles/:article_id/comments

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -442,7 +442,6 @@ describe("/api/articles/:article_id/comments", () => {
         .get("/api/articles/1/comments")
         .expect(200)
         .then(({ body: { comments } }) => {
-          expect(comments).toHaveLength(11);
           comments.forEach((comment) =>
             expect(comment).toMatchObject({
               comment_id: expect.any(Number),
@@ -482,76 +481,130 @@ describe("/api/articles/:article_id/comments", () => {
     });
   });
 
-  describe("POST", () => {
-    test("POST: 201 - add a new comment for the specified article_id and respond with an object representing the posted comment", () => {
-      const input = {
-        body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet sapien vitae nibh convallis mollis. Donec feugiat elit eu enim gravida imperdiet.",
-        author: "lurker",
-      };
-
+  describe("Pagination query", () => {
+    test("GET: 200 - respond with an array of comments limited to 10 comments by default", () => {
       return request(app)
-        .post("/api/articles/1/comments")
-        .send(input)
-        .expect(201)
-        .then(({ body: { newComment } }) => {
-          expect(newComment).toMatchObject({
-            body: input.body,
-            article_id: 1,
-            author: input.author,
-            comment_id: expect.any(Number),
-            created_at: expect.any(String),
-            votes: 0,
-          });
+        .get("/api/articles/1/comments")
+        .expect(200)
+        .then(({ body: { comments } }) => expect(comments).toHaveLength(10));
+    });
+
+    test("GET: 200 - respond with an array of comments limited by the specified limit", () => {
+      return request(app)
+        .get("/api/articles/1/comments?limit=5")
+        .expect(200)
+        .then(({ body: { comments } }) => expect(comments).toHaveLength(5));
+    });
+
+    test("GET: 200 - respond with an array of comments limited by the specified limit and for the specified page ", () => {
+      return request(app)
+        .get("/api/articles/1/comments?limit=3&p=2")
+        .expect(200)
+        .then(({ body: { comments } }) => {
+          expect(comments).toHaveLength(3);
+          expect(comments[0].comment_id).not.toBe(5);
         });
     });
 
-    test('POST: 400 - respond with message "Bad request" when the given new comment does not specify body and/or author', () => {
-      const missingEverything = {};
-      const missingBody = { author: "lurker" };
-      const missingAuthor = {
-        body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet sapien vitae nibh convallis mollis. Donec feugiat elit eu enim gravida imperdiet.",
-      };
+    test('GET: 400 - respond with message "Bad request" when specified limit is not a number', () => {
+      return request(app)
+        .get("/api/articles/1/comments?limit=not-a-number")
+        .expect(400)
+        .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
+    });
 
-      const testCases = [missingEverything, missingBody, missingAuthor];
-      const promises = testCases.map((testCase) => {
-        return request(app).post("/api/articles/1/comments").send(testCase);
+    test('GET: 400 - respond with message "Bad request" when specified page is not a number', () => {
+      return request(app)
+        .get("/api/articles/1/comments?p=not-a-number")
+        .expect(400)
+        .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
+    });
+
+    test('GET: 400 - respond with message "Bad request" when specified limit is negative', () => {
+      return request(app)
+        .get("/api/articles/1/comments?limit=-10")
+        .expect(400)
+        .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
+    });
+
+    test('GET: 400 - respond with message "Bad request" when specified page is negative', () => {
+      return request(app)
+        .get("/api/articles/1/comments?p=-3")
+        .expect(400)
+        .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
+    });
+  });
+});
+
+describe("POST", () => {
+  test("POST: 201 - add a new comment for the specified article_id and respond with an object representing the posted comment", () => {
+    const input = {
+      body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet sapien vitae nibh convallis mollis. Donec feugiat elit eu enim gravida imperdiet.",
+      author: "lurker",
+    };
+
+    return request(app)
+      .post("/api/articles/1/comments")
+      .send(input)
+      .expect(201)
+      .then(({ body: { newComment } }) => {
+        expect(newComment).toMatchObject({
+          body: input.body,
+          article_id: 1,
+          author: input.author,
+          comment_id: expect.any(Number),
+          created_at: expect.any(String),
+          votes: 0,
+        });
       });
+  });
 
-      return Promise.all(promises).then((responses) => {
-        responses.forEach((response) => {
-          expect(response.statusCode).toBe(400);
-          expect(response.body.msg).toBe("Bad request");
-        });
+  test('POST: 400 - respond with message "Bad request" when the given new comment does not specify body and/or author', () => {
+    const missingEverything = {};
+    const missingBody = { author: "lurker" };
+    const missingAuthor = {
+      body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet sapien vitae nibh convallis mollis. Donec feugiat elit eu enim gravida imperdiet.",
+    };
+
+    const testCases = [missingEverything, missingBody, missingAuthor];
+    const promises = testCases.map((testCase) => {
+      return request(app).post("/api/articles/1/comments").send(testCase);
+    });
+
+    return Promise.all(promises).then((responses) => {
+      responses.forEach((response) => {
+        expect(response.statusCode).toBe(400);
+        expect(response.body.msg).toBe("Bad request");
       });
     });
+  });
 
-    test('POST: 404 - respond with message "Not found" when the specified author does not exist in the database', () => {
-      const input = {
-        body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet sapien vitae nibh convallis mollis. Donec feugiat elit eu enim gravida imperdiet.",
-        author: "idonotexist",
-      };
+  test('POST: 404 - respond with message "Not found" when the specified author does not exist in the database', () => {
+    const input = {
+      body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet sapien vitae nibh convallis mollis. Donec feugiat elit eu enim gravida imperdiet.",
+      author: "idonotexist",
+    };
 
-      return request(app)
-        .post("/api/articles/1/comments")
-        .send(input)
-        .expect(404)
-        .then(({ body: { msg } }) => expect(msg).toBe("Not found"));
-    });
+    return request(app)
+      .post("/api/articles/1/comments")
+      .send(input)
+      .expect(404)
+      .then(({ body: { msg } }) => expect(msg).toBe("Not found"));
+  });
 
-    test('POST: 404 - respond with message "Not found" when the specified article_id does not exist in the database', () => {
-      const input = {
-        body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet sapien vitae nibh convallis mollis. Donec feugiat elit eu enim gravida imperdiet.",
-        author: "lurker",
-      };
+  test('POST: 404 - respond with message "Not found" when the specified article_id does not exist in the database', () => {
+    const input = {
+      body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet sapien vitae nibh convallis mollis. Donec feugiat elit eu enim gravida imperdiet.",
+      author: "lurker",
+    };
 
-      return request(app)
-        .post("/api/articles/9999/comments")
-        .send(input)
-        .expect(404)
-        .then(({ body: { msg } }) => {
-          expect(msg).toBe("Not found");
-        });
-    });
+    return request(app)
+      .post("/api/articles/9999/comments")
+      .send(input)
+      .expect(404)
+      .then(({ body: { msg } }) => {
+        expect(msg).toBe("Not found");
+      });
   });
 });
 

--- a/endpoints.json
+++ b/endpoints.json
@@ -43,7 +43,7 @@
 
   "GET /api/articles/:article_id/comments": {
     "description": "serves an array of comments for the given article_id ordered by the most recent comment first",
-    "queries": [],
+    "queries": ["limit", "p"],
     "exampleResponse": {
       "comments": [
         {


### PR DESCRIPTION
Add ability specify pagination queries for `/api/articles/:article_id/comments`.

- Tested:
  - `200` - respond with an array of comment objects limited to 10 comments by default
  - `200` - respond with an array of comments limited by the specified `limit`
  - `200` - respond with an array of comments limited by the specified `limit` and page (`p`)
  - `400` - "Bad request" when specified `limit` is not a number
  - `400` - "Bad request" when specified `p` is not a number
  - `400` - "Bad request" when specified `limit` is negative
  - `400` - "Bad request" when specified `p` is negative
  
- Fixed a previous test which failed because it was asserting against an expected number of comments being returned
- Modified corresponding `controller` and `model` functions
- Refactored `controller` function to use `Promise.all` to make multiple `model` requests
- Updated `endpoints.json`, adding the `limit` and `p` to query options