### PR TITLE
add POST /api/topics

### DIFF
--- a/controllers/topics.controller.js
+++ b/controllers/topics.controller.js
@@ -1,4 +1,4 @@
-const { selectTopics } = require("../models/topics.model");
+const { selectTopics, insertNewTopic } = require("../models/topics.model");
 
 function getTopics(request, response, next) {
   return selectTopics()
@@ -6,4 +6,21 @@ function getTopics(request, response, next) {
     .catch(next);
 }
 
-module.exports = { getTopics };
+function postNewTopic(request, response, next) {
+  const minRequiredKeys = ["slug", "description"];
+  const requestedNewTopic = request.body;
+  const newTopicKeys = Object.keys(requestedNewTopic);
+
+  // check the requested new topic has the required keys
+  if (
+    newTopicKeys.length < minRequiredKeys.length ||
+    !minRequiredKeys.every((key) => newTopicKeys.includes(key))
+  ) {
+    return response.status(400).send({ status_code: 400, msg: "Bad request" });
+  }
+
+  return insertNewTopic(request.body)
+    .then((newTopic) => response.status(201).send({ newTopic }))
+    .catch(next);
+}
+module.exports = { getTopics, postNewTopic };

--- a/endpoints.json
+++ b/endpoints.json
@@ -166,5 +166,13 @@
         "created_at": "2024-10-15T11:28:08.445Z"
       }
     }
+  },
+
+  "POST /api/topics": {
+    "description": "add a new topic, returns with the newly created topic",
+    "queries": [],
+    "exampleResponse": {
+      "newTopic": [{ "slug": "football", "description": "Footie!" }]
+    }
   }
 }

--- a/error-handlers.js
+++ b/error-handlers.js
@@ -13,12 +13,11 @@ function psqlErrorHandler(error, request, response, next) {
     switch (error.code) {
       case "22P02": // wrong data type
       case "23502": // not-null violations
+      case "23505": // primary key violations
         return response.status(400).send({ msg: "Bad request" });
       case "23503": // constraint violations
         return response.status(404).send({ msg: "Not found" });
       default:
-        console.log(error);
-
         return response
           .status(500)
           .send({ msg: `Database error, code: ${error.code}` });

--- a/models/topics.model.js
+++ b/models/topics.model.js
@@ -1,7 +1,21 @@
 const db = require("../db/connection");
+const format = require("pg-format");
 
 function selectTopics() {
   return db.query("SELECT * FROM topics").then((results) => results.rows);
 }
 
-module.exports = { selectTopics };
+function insertNewTopic(newTopic) {
+  return db
+    .query(
+      format(
+        `INSERT INTO topics (slug, description) 
+      VALUES %L 
+      RETURNING *`,
+        [[newTopic.slug, newTopic.description]]
+      )
+    )
+    .then((results) => results.rows[0]);
+}
+
+module.exports = { selectTopics, insertNewTopic };

--- a/routers/topics.router.js
+++ b/routers/topics.router.js
@@ -1,7 +1,7 @@
 const topicsRouter = require("express").Router();
-const { getTopics } = require("../controllers/topics.controller");
+const { getTopics, postNewTopic } = require("../controllers/topics.controller");
 
 // handle requests for /api/topics
-topicsRouter.get("/", getTopics);
+topicsRouter.route("/").get(getTopics).post(postNewTopic);
 
 module.exports = topicsRouter;


### PR DESCRIPTION
Add ability to create a new `topic`

- Tested:
  - `201` - successfully add a new topic and respond with an object representing the newly created topic
  - `400` - "Bad request" when passed in object does not have the required keys 
  - `400` - "Bad request" when trying to add a topic that already exists

- Updated corresponding `controller` and `model` functions
- Updated `endpoints.json` file with details for the new method
- Updated PSQL error handler function to handle primary key violations
- Amended topics router to accommodate new method