### PR TITLE
add DELETE /api/articles/:article_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -242,6 +242,19 @@ describe("/api/articles/:article_id", () => {
         .then(({ body: { msg } }) => expect(msg).toBe("Not found"));
     });
   });
+
+  describe("DELETE", () => {
+    test("DELETE: 204 - respond with status code of 204 with no content on successfully deleting an article", () => {
+      return request(app).delete("/api/articles/1").expect(204);
+    });
+
+    test('DELETE: 400 - respond with message "Bad request" when the specified article_id is not the correct data type', () => {
+      return request(app)
+        .delete("/api/articles/not-a-number")
+        .expect(400)
+        .then(({ body: { msg } }) => expect(msg).toBe("Bad request"));
+    });
+  });
 });
 
 describe("/api/articles", () => {

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -3,6 +3,7 @@ const {
   selectArticles,
   updateArticleById,
   insertNewArticle,
+  deleteArticleByArticleId,
 } = require("../models/articles.model");
 
 function getArticleById(request, response, next) {
@@ -72,9 +73,21 @@ function postNewArticle(request, response, next) {
     .catch(next);
 }
 
+function removeArticleByArticleId(request, response, next) {
+  const { article_id } = request.params;
+
+  if (isNaN(article_id))
+    response.status(400).send({ status_code: 400, msg: "Bad request" });
+
+  return deleteArticleByArticleId(article_id)
+    .then(() => response.status(204).send())
+    .catch(next);
+}
+
 module.exports = {
   getArticleById,
   getArticles,
   patchArticleById,
   postNewArticle,
+  removeArticleByArticleId,
 };

--- a/db/seeds/seed.js
+++ b/db/seeds/seed.js
@@ -1,10 +1,10 @@
-const format = require('pg-format');
-const db = require('../connection');
+const format = require("pg-format");
+const db = require("../connection");
 const {
   convertTimestampToDate,
   createRef,
   formatComments,
-} = require('./utils');
+} = require("./utils");
 
 const seed = ({ topicData, userData, articleData, commentData }) => {
   return db
@@ -52,7 +52,7 @@ const seed = ({ topicData, userData, articleData, commentData }) => {
       CREATE TABLE comments (
         comment_id SERIAL PRIMARY KEY,
         body VARCHAR NOT NULL,
-        article_id INT REFERENCES articles(article_id) NOT NULL,
+        article_id INT REFERENCES articles(article_id) ON DELETE CASCADE NOT NULL,
         author VARCHAR REFERENCES users(username) NOT NULL,
         votes INT DEFAULT 0 NOT NULL,
         created_at TIMESTAMP DEFAULT NOW()
@@ -60,13 +60,13 @@ const seed = ({ topicData, userData, articleData, commentData }) => {
     })
     .then(() => {
       const insertTopicsQueryStr = format(
-        'INSERT INTO topics (slug, description) VALUES %L;',
+        "INSERT INTO topics (slug, description) VALUES %L;",
         topicData.map(({ slug, description }) => [slug, description])
       );
       const topicsPromise = db.query(insertTopicsQueryStr);
 
       const insertUsersQueryStr = format(
-        'INSERT INTO users ( username, name, avatar_url) VALUES %L;',
+        "INSERT INTO users ( username, name, avatar_url) VALUES %L;",
         userData.map(({ username, name, avatar_url }) => [
           username,
           name,
@@ -80,7 +80,7 @@ const seed = ({ topicData, userData, articleData, commentData }) => {
     .then(() => {
       const formattedArticleData = articleData.map(convertTimestampToDate);
       const insertArticlesQueryStr = format(
-        'INSERT INTO articles (title, topic, author, body, created_at, votes, article_img_url) VALUES %L RETURNING *;',
+        "INSERT INTO articles (title, topic, author, body, created_at, votes, article_img_url) VALUES %L RETURNING *;",
         formattedArticleData.map(
           ({
             title,
@@ -97,11 +97,11 @@ const seed = ({ topicData, userData, articleData, commentData }) => {
       return db.query(insertArticlesQueryStr);
     })
     .then(({ rows: articleRows }) => {
-      const articleIdLookup = createRef(articleRows, 'title', 'article_id');
+      const articleIdLookup = createRef(articleRows, "title", "article_id");
       const formattedCommentData = formatComments(commentData, articleIdLookup);
 
       const insertCommentsQueryStr = format(
-        'INSERT INTO comments (body, author, article_id, votes, created_at) VALUES %L;',
+        "INSERT INTO comments (body, author, article_id, votes, created_at) VALUES %L;",
         formattedCommentData.map(
           ({ body, author, article_id, votes = 0, created_at }) => [
             body,

--- a/endpoints.json
+++ b/endpoints.json
@@ -94,6 +94,12 @@
     }
   },
 
+  "DELETE /api/articles/:article_id": {
+    "description": "deletes the specified article",
+    "queries": [],
+    "exampleResponse": "No response content is returned on successful delete"
+  },
+
   "DELETE /api/comments/:comment_id": {
     "description": "deletes the specified comment",
     "queries": [],

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -124,9 +124,15 @@ function insertNewArticle(newArticle) {
     )
     .then((results) => results.rows[0].article_id);
 }
+
+function deleteArticleByArticleId(article_id) {
+  return db.query("DELETE FROM articles WHERE article_id = $1", [article_id]);
+}
+
 module.exports = {
   selectArticleById,
   selectArticles,
   updateArticleById,
   insertNewArticle,
+  deleteArticleByArticleId,
 };

--- a/routers/articles.router.js
+++ b/routers/articles.router.js
@@ -4,6 +4,7 @@ const {
   getArticles,
   patchArticleById,
   postNewArticle,
+  removeArticleByArticleId,
 } = require("../controllers/articles.controller");
 
 const {
@@ -18,6 +19,7 @@ articlesRouter.route("/").get(getArticles).post(postNewArticle);
 articlesRouter
   .route("/:article_id")
   .get(getArticleById)
+  .delete(removeArticleByArticleId)
   .patch(patchArticleById);
 
 // handle requests for /api/articles/:article_id/comments


### PR DESCRIPTION
Add ability to delete a specific `article`.

- Tested:
  - `204` - successfully delete specified `article`, respond with no content
  - `400` - "Bad request" when the specified `article_id is not a number

- Changed foreign key to `articles` table on `comments` to `ON DELETE CASCADE`
- Created corresponding `controller` and `model` functions
- Updated routing for the endpoint
- Updated `endpoints.json` with details about the `DELETE` method for this endpoint